### PR TITLE
1.11.354-SHADED release preparation

### DIFF
--- a/aws-java-sdk-acm/pom.xml
+++ b/aws-java-sdk-acm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-acm</artifactId>

--- a/aws-java-sdk-acmpca/pom.xml
+++ b/aws-java-sdk-acmpca/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-acmpca</artifactId>

--- a/aws-java-sdk-alexaforbusiness/pom.xml
+++ b/aws-java-sdk-alexaforbusiness/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-alexaforbusiness</artifactId>

--- a/aws-java-sdk-api-gateway/pom.xml
+++ b/aws-java-sdk-api-gateway/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-api-gateway</artifactId>

--- a/aws-java-sdk-applicationautoscaling/pom.xml
+++ b/aws-java-sdk-applicationautoscaling/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-applicationautoscaling</artifactId>

--- a/aws-java-sdk-appstream/pom.xml
+++ b/aws-java-sdk-appstream/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-appstream</artifactId>

--- a/aws-java-sdk-appsync/pom.xml
+++ b/aws-java-sdk-appsync/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-appsync</artifactId>

--- a/aws-java-sdk-athena/pom.xml
+++ b/aws-java-sdk-athena/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-athena</artifactId>

--- a/aws-java-sdk-autoscaling/pom.xml
+++ b/aws-java-sdk-autoscaling/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-autoscaling</artifactId>

--- a/aws-java-sdk-autoscalingplans/pom.xml
+++ b/aws-java-sdk-autoscalingplans/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-autoscalingplans</artifactId>

--- a/aws-java-sdk-batch/pom.xml
+++ b/aws-java-sdk-batch/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-batch</artifactId>

--- a/aws-java-sdk-bom/pom.xml
+++ b/aws-java-sdk-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-bom</artifactId>

--- a/aws-java-sdk-budgets/pom.xml
+++ b/aws-java-sdk-budgets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-budgets</artifactId>

--- a/aws-java-sdk-bundle/pom.xml
+++ b/aws-java-sdk-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-pom</artifactId>
-        <version>1.11.355-SNAPSHOT</version>
+        <version>1.11.354-SHADED</version>
     </parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-bundle</artifactId>
@@ -24,7 +24,7 @@
         <artifactId>aws-java-sdk</artifactId>
         <groupId>com.amazonaws</groupId>
         <optional>false</optional>
-        <version>1.11.355-SNAPSHOT</version>
+        <version>1.11.354-SHADED</version>
     </dependency>
 </dependencies>
 

--- a/aws-java-sdk-cloud9/pom.xml
+++ b/aws-java-sdk-cloud9/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cloud9</artifactId>

--- a/aws-java-sdk-clouddirectory/pom.xml
+++ b/aws-java-sdk-clouddirectory/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-clouddirectory</artifactId>

--- a/aws-java-sdk-cloudformation/pom.xml
+++ b/aws-java-sdk-cloudformation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cloudformation</artifactId>

--- a/aws-java-sdk-cloudfront/pom.xml
+++ b/aws-java-sdk-cloudfront/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cloudfront</artifactId>

--- a/aws-java-sdk-cloudhsm/pom.xml
+++ b/aws-java-sdk-cloudhsm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cloudhsm</artifactId>

--- a/aws-java-sdk-cloudhsmv2/pom.xml
+++ b/aws-java-sdk-cloudhsmv2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cloudhsmv2</artifactId>

--- a/aws-java-sdk-cloudsearch/pom.xml
+++ b/aws-java-sdk-cloudsearch/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cloudsearch</artifactId>

--- a/aws-java-sdk-cloudtrail/pom.xml
+++ b/aws-java-sdk-cloudtrail/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cloudtrail</artifactId>

--- a/aws-java-sdk-cloudwatch/pom.xml
+++ b/aws-java-sdk-cloudwatch/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cloudwatch</artifactId>

--- a/aws-java-sdk-cloudwatchmetrics/pom.xml
+++ b/aws-java-sdk-cloudwatchmetrics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cloudwatchmetrics</artifactId>

--- a/aws-java-sdk-code-generator/pom.xml
+++ b/aws-java-sdk-code-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-code-generator</artifactId>

--- a/aws-java-sdk-codebuild/pom.xml
+++ b/aws-java-sdk-codebuild/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-codebuild</artifactId>

--- a/aws-java-sdk-codecommit/pom.xml
+++ b/aws-java-sdk-codecommit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-codecommit</artifactId>

--- a/aws-java-sdk-codedeploy/pom.xml
+++ b/aws-java-sdk-codedeploy/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-codedeploy</artifactId>

--- a/aws-java-sdk-codegen-maven-plugin/pom.xml
+++ b/aws-java-sdk-codegen-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-codegen-maven-plugin</artifactId>

--- a/aws-java-sdk-codepipeline/pom.xml
+++ b/aws-java-sdk-codepipeline/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-codepipeline</artifactId>

--- a/aws-java-sdk-codestar/pom.xml
+++ b/aws-java-sdk-codestar/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-codestar</artifactId>

--- a/aws-java-sdk-cognitoidentity/pom.xml
+++ b/aws-java-sdk-cognitoidentity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cognitoidentity</artifactId>

--- a/aws-java-sdk-cognitoidp/pom.xml
+++ b/aws-java-sdk-cognitoidp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cognitoidp</artifactId>

--- a/aws-java-sdk-cognitosync/pom.xml
+++ b/aws-java-sdk-cognitosync/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-cognitosync</artifactId>

--- a/aws-java-sdk-comprehend/pom.xml
+++ b/aws-java-sdk-comprehend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-comprehend</artifactId>

--- a/aws-java-sdk-config/pom.xml
+++ b/aws-java-sdk-config/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-config</artifactId>

--- a/aws-java-sdk-connect/pom.xml
+++ b/aws-java-sdk-connect/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-connect</artifactId>

--- a/aws-java-sdk-core/pom.xml
+++ b/aws-java-sdk-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-core</artifactId>

--- a/aws-java-sdk-costandusagereport/pom.xml
+++ b/aws-java-sdk-costandusagereport/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-costandusagereport</artifactId>

--- a/aws-java-sdk-costexplorer/pom.xml
+++ b/aws-java-sdk-costexplorer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-costexplorer</artifactId>

--- a/aws-java-sdk-datapipeline/pom.xml
+++ b/aws-java-sdk-datapipeline/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-datapipeline</artifactId>

--- a/aws-java-sdk-dax/pom.xml
+++ b/aws-java-sdk-dax/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-dax</artifactId>

--- a/aws-java-sdk-devicefarm/pom.xml
+++ b/aws-java-sdk-devicefarm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-devicefarm</artifactId>

--- a/aws-java-sdk-directconnect/pom.xml
+++ b/aws-java-sdk-directconnect/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-directconnect</artifactId>

--- a/aws-java-sdk-directory/pom.xml
+++ b/aws-java-sdk-directory/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-directory</artifactId>

--- a/aws-java-sdk-discovery/pom.xml
+++ b/aws-java-sdk-discovery/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-discovery</artifactId>

--- a/aws-java-sdk-dms/pom.xml
+++ b/aws-java-sdk-dms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-dms</artifactId>

--- a/aws-java-sdk-dynamodb/pom.xml
+++ b/aws-java-sdk-dynamodb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-dynamodb</artifactId>

--- a/aws-java-sdk-ec2/pom.xml
+++ b/aws-java-sdk-ec2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-ec2</artifactId>

--- a/aws-java-sdk-ecr/pom.xml
+++ b/aws-java-sdk-ecr/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-ecr</artifactId>

--- a/aws-java-sdk-ecs/pom.xml
+++ b/aws-java-sdk-ecs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-ecs</artifactId>

--- a/aws-java-sdk-efs/pom.xml
+++ b/aws-java-sdk-efs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-efs</artifactId>

--- a/aws-java-sdk-eks/pom.xml
+++ b/aws-java-sdk-eks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-eks</artifactId>

--- a/aws-java-sdk-elasticache/pom.xml
+++ b/aws-java-sdk-elasticache/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-elasticache</artifactId>

--- a/aws-java-sdk-elasticbeanstalk/pom.xml
+++ b/aws-java-sdk-elasticbeanstalk/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-elasticbeanstalk</artifactId>

--- a/aws-java-sdk-elasticloadbalancing/pom.xml
+++ b/aws-java-sdk-elasticloadbalancing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-elasticloadbalancing</artifactId>

--- a/aws-java-sdk-elasticloadbalancingv2/pom.xml
+++ b/aws-java-sdk-elasticloadbalancingv2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-elasticloadbalancingv2</artifactId>

--- a/aws-java-sdk-elasticsearch/pom.xml
+++ b/aws-java-sdk-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-elasticsearch</artifactId>

--- a/aws-java-sdk-elastictranscoder/pom.xml
+++ b/aws-java-sdk-elastictranscoder/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-elastictranscoder</artifactId>

--- a/aws-java-sdk-emr/pom.xml
+++ b/aws-java-sdk-emr/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-emr</artifactId>

--- a/aws-java-sdk-events/pom.xml
+++ b/aws-java-sdk-events/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-events</artifactId>

--- a/aws-java-sdk-fms/pom.xml
+++ b/aws-java-sdk-fms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-fms</artifactId>

--- a/aws-java-sdk-gamelift/pom.xml
+++ b/aws-java-sdk-gamelift/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-gamelift</artifactId>

--- a/aws-java-sdk-glacier/pom.xml
+++ b/aws-java-sdk-glacier/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-glacier</artifactId>

--- a/aws-java-sdk-glue/pom.xml
+++ b/aws-java-sdk-glue/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-glue</artifactId>

--- a/aws-java-sdk-greengrass/pom.xml
+++ b/aws-java-sdk-greengrass/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-greengrass</artifactId>

--- a/aws-java-sdk-guardduty/pom.xml
+++ b/aws-java-sdk-guardduty/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-guardduty</artifactId>

--- a/aws-java-sdk-health/pom.xml
+++ b/aws-java-sdk-health/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-health</artifactId>

--- a/aws-java-sdk-iam/pom.xml
+++ b/aws-java-sdk-iam/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-iam</artifactId>

--- a/aws-java-sdk-importexport/pom.xml
+++ b/aws-java-sdk-importexport/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-importexport</artifactId>

--- a/aws-java-sdk-inspector/pom.xml
+++ b/aws-java-sdk-inspector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-inspector</artifactId>

--- a/aws-java-sdk-iot/pom.xml
+++ b/aws-java-sdk-iot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-iot</artifactId>

--- a/aws-java-sdk-iot1clickdevices/pom.xml
+++ b/aws-java-sdk-iot1clickdevices/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-iot1clickdevices</artifactId>

--- a/aws-java-sdk-iot1clickprojects/pom.xml
+++ b/aws-java-sdk-iot1clickprojects/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-iot1clickprojects</artifactId>

--- a/aws-java-sdk-iotanalytics/pom.xml
+++ b/aws-java-sdk-iotanalytics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-iotanalytics</artifactId>

--- a/aws-java-sdk-iotjobsdataplane/pom.xml
+++ b/aws-java-sdk-iotjobsdataplane/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-iotjobsdataplane</artifactId>

--- a/aws-java-sdk-kinesis/pom.xml
+++ b/aws-java-sdk-kinesis/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-kinesis</artifactId>

--- a/aws-java-sdk-kinesisvideo/pom.xml
+++ b/aws-java-sdk-kinesisvideo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-kinesisvideo</artifactId>

--- a/aws-java-sdk-kms/pom.xml
+++ b/aws-java-sdk-kms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-kms</artifactId>

--- a/aws-java-sdk-lambda/pom.xml
+++ b/aws-java-sdk-lambda/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-lambda</artifactId>

--- a/aws-java-sdk-lex/pom.xml
+++ b/aws-java-sdk-lex/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-lex</artifactId>

--- a/aws-java-sdk-lexmodelbuilding/pom.xml
+++ b/aws-java-sdk-lexmodelbuilding/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-lexmodelbuilding</artifactId>

--- a/aws-java-sdk-lightsail/pom.xml
+++ b/aws-java-sdk-lightsail/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-lightsail</artifactId>

--- a/aws-java-sdk-logs/pom.xml
+++ b/aws-java-sdk-logs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-logs</artifactId>

--- a/aws-java-sdk-machinelearning/pom.xml
+++ b/aws-java-sdk-machinelearning/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-machinelearning</artifactId>

--- a/aws-java-sdk-macie/pom.xml
+++ b/aws-java-sdk-macie/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-macie</artifactId>

--- a/aws-java-sdk-marketplacecommerceanalytics/pom.xml
+++ b/aws-java-sdk-marketplacecommerceanalytics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-marketplacecommerceanalytics</artifactId>

--- a/aws-java-sdk-marketplaceentitlement/pom.xml
+++ b/aws-java-sdk-marketplaceentitlement/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-marketplaceentitlement</artifactId>

--- a/aws-java-sdk-marketplacemeteringservice/pom.xml
+++ b/aws-java-sdk-marketplacemeteringservice/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-marketplacemeteringservice</artifactId>

--- a/aws-java-sdk-mechanicalturkrequester/pom.xml
+++ b/aws-java-sdk-mechanicalturkrequester/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-mechanicalturkrequester</artifactId>

--- a/aws-java-sdk-mediaconvert/pom.xml
+++ b/aws-java-sdk-mediaconvert/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-mediaconvert</artifactId>

--- a/aws-java-sdk-medialive/pom.xml
+++ b/aws-java-sdk-medialive/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-medialive</artifactId>

--- a/aws-java-sdk-mediapackage/pom.xml
+++ b/aws-java-sdk-mediapackage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-mediapackage</artifactId>

--- a/aws-java-sdk-mediastore/pom.xml
+++ b/aws-java-sdk-mediastore/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-mediastore</artifactId>

--- a/aws-java-sdk-mediastoredata/pom.xml
+++ b/aws-java-sdk-mediastoredata/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-mediastoredata</artifactId>

--- a/aws-java-sdk-mediatailor/pom.xml
+++ b/aws-java-sdk-mediatailor/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-mediatailor</artifactId>

--- a/aws-java-sdk-migrationhub/pom.xml
+++ b/aws-java-sdk-migrationhub/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-migrationhub</artifactId>

--- a/aws-java-sdk-mobile/pom.xml
+++ b/aws-java-sdk-mobile/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-mobile</artifactId>

--- a/aws-java-sdk-models/pom.xml
+++ b/aws-java-sdk-models/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-models</artifactId>

--- a/aws-java-sdk-mq/pom.xml
+++ b/aws-java-sdk-mq/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-mq</artifactId>

--- a/aws-java-sdk-neptune/pom.xml
+++ b/aws-java-sdk-neptune/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-neptune</artifactId>

--- a/aws-java-sdk-opensdk/pom.xml
+++ b/aws-java-sdk-opensdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 	<groupId>com.amazonaws</groupId>
 	<artifactId>aws-java-sdk-pom</artifactId>
-	<version>1.11.355-SNAPSHOT</version>
+	<version>1.11.354-SHADED</version>
     </parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-opensdk</artifactId>
@@ -22,7 +22,7 @@
 	    <artifactId>aws-java-sdk-core</artifactId>
 	    <groupId>com.amazonaws</groupId>
 	    <optional>false</optional>
-	   <version>1.11.355-SNAPSHOT</version>
+	   <version>1.11.354-SHADED</version>
 	</dependency>
     </dependencies>
     <build>

--- a/aws-java-sdk-opsworks/pom.xml
+++ b/aws-java-sdk-opsworks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-opsworks</artifactId>

--- a/aws-java-sdk-opsworkscm/pom.xml
+++ b/aws-java-sdk-opsworkscm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-opsworkscm</artifactId>

--- a/aws-java-sdk-organizations/pom.xml
+++ b/aws-java-sdk-organizations/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-organizations</artifactId>

--- a/aws-java-sdk-osgi/pom.xml
+++ b/aws-java-sdk-osgi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-osgi</artifactId>

--- a/aws-java-sdk-pi/pom.xml
+++ b/aws-java-sdk-pi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-pi</artifactId>

--- a/aws-java-sdk-pinpoint/pom.xml
+++ b/aws-java-sdk-pinpoint/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-pinpoint</artifactId>

--- a/aws-java-sdk-polly/pom.xml
+++ b/aws-java-sdk-polly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-polly</artifactId>

--- a/aws-java-sdk-pricing/pom.xml
+++ b/aws-java-sdk-pricing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-pricing</artifactId>

--- a/aws-java-sdk-rds/pom.xml
+++ b/aws-java-sdk-rds/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-rds</artifactId>

--- a/aws-java-sdk-redshift/pom.xml
+++ b/aws-java-sdk-redshift/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-redshift</artifactId>

--- a/aws-java-sdk-rekognition/pom.xml
+++ b/aws-java-sdk-rekognition/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-rekognition</artifactId>

--- a/aws-java-sdk-resourcegroups/pom.xml
+++ b/aws-java-sdk-resourcegroups/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-resourcegroups</artifactId>

--- a/aws-java-sdk-resourcegroupstaggingapi/pom.xml
+++ b/aws-java-sdk-resourcegroupstaggingapi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-resourcegroupstaggingapi</artifactId>

--- a/aws-java-sdk-route53/pom.xml
+++ b/aws-java-sdk-route53/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-route53</artifactId>

--- a/aws-java-sdk-s3/pom.xml
+++ b/aws-java-sdk-s3/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-s3</artifactId>

--- a/aws-java-sdk-sagemaker/pom.xml
+++ b/aws-java-sdk-sagemaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-sagemaker</artifactId>

--- a/aws-java-sdk-sagemakerruntime/pom.xml
+++ b/aws-java-sdk-sagemakerruntime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-sagemakerruntime</artifactId>

--- a/aws-java-sdk-secretsmanager/pom.xml
+++ b/aws-java-sdk-secretsmanager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-secretsmanager</artifactId>

--- a/aws-java-sdk-serverlessapplicationrepository/pom.xml
+++ b/aws-java-sdk-serverlessapplicationrepository/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-serverlessapplicationrepository</artifactId>

--- a/aws-java-sdk-servermigration/pom.xml
+++ b/aws-java-sdk-servermigration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-servermigration</artifactId>

--- a/aws-java-sdk-servicecatalog/pom.xml
+++ b/aws-java-sdk-servicecatalog/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-servicecatalog</artifactId>

--- a/aws-java-sdk-servicediscovery/pom.xml
+++ b/aws-java-sdk-servicediscovery/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-servicediscovery</artifactId>

--- a/aws-java-sdk-ses/pom.xml
+++ b/aws-java-sdk-ses/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-ses</artifactId>

--- a/aws-java-sdk-shield/pom.xml
+++ b/aws-java-sdk-shield/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-shield</artifactId>

--- a/aws-java-sdk-simpledb/pom.xml
+++ b/aws-java-sdk-simpledb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-simpledb</artifactId>

--- a/aws-java-sdk-simpleworkflow/pom.xml
+++ b/aws-java-sdk-simpleworkflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-simpleworkflow</artifactId>

--- a/aws-java-sdk-snowball/pom.xml
+++ b/aws-java-sdk-snowball/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-snowball</artifactId>

--- a/aws-java-sdk-sns/pom.xml
+++ b/aws-java-sdk-sns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-sns</artifactId>

--- a/aws-java-sdk-sqs/pom.xml
+++ b/aws-java-sdk-sqs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-sqs</artifactId>

--- a/aws-java-sdk-ssm/pom.xml
+++ b/aws-java-sdk-ssm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-ssm</artifactId>

--- a/aws-java-sdk-stepfunctions/pom.xml
+++ b/aws-java-sdk-stepfunctions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-stepfunctions</artifactId>

--- a/aws-java-sdk-storagegateway/pom.xml
+++ b/aws-java-sdk-storagegateway/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-storagegateway</artifactId>

--- a/aws-java-sdk-sts/pom.xml
+++ b/aws-java-sdk-sts/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-sts</artifactId>

--- a/aws-java-sdk-support/pom.xml
+++ b/aws-java-sdk-support/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-support</artifactId>

--- a/aws-java-sdk-test-utils/pom.xml
+++ b/aws-java-sdk-test-utils/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-test-utils</artifactId>

--- a/aws-java-sdk-transcribe/pom.xml
+++ b/aws-java-sdk-transcribe/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-transcribe</artifactId>

--- a/aws-java-sdk-translate/pom.xml
+++ b/aws-java-sdk-translate/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-translate</artifactId>

--- a/aws-java-sdk-waf/pom.xml
+++ b/aws-java-sdk-waf/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-waf</artifactId>

--- a/aws-java-sdk-workdocs/pom.xml
+++ b/aws-java-sdk-workdocs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-workdocs</artifactId>

--- a/aws-java-sdk-workmail/pom.xml
+++ b/aws-java-sdk-workmail/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-workmail</artifactId>

--- a/aws-java-sdk-workspaces/pom.xml
+++ b/aws-java-sdk-workspaces/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-workspaces</artifactId>

--- a/aws-java-sdk-xray/pom.xml
+++ b/aws-java-sdk-xray/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-xray</artifactId>

--- a/aws-java-sdk/pom.xml
+++ b/aws-java-sdk/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk</artifactId>

--- a/jmespath-java/pom.xml
+++ b/jmespath-java/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.355-SNAPSHOT</version>
+    <version>1.11.354-SHADED</version>
   </parent>
   <groupId>com.amazonaws</groupId>
   <artifactId>jmespath-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-pom</artifactId>
-  <version>1.11.355-SNAPSHOT</version>
+  <version>1.11.354-SHADED</version>
   <packaging>pom</packaging>
   <name>AWS SDK for Java</name>
   <description>The Amazon Web Services SDK for Java provides Java APIs


### PR DESCRIPTION
This was done as part of our AWS library bump. To avoid bumping multiple jars (e.g httpclient) which causes htmlunit bot to start failing we decided to go with the route of using a shaded jar[1] as a dependency. The shaded jar encompasses not just our package but also its dependencies in one single JAR file.

From our RiskIQ application we can consume the uber jar and not worry about bumping other dependencies which the aws sdk might need like the latest version of **httpclient** and **httpclient-core**.


[1]-https://softwareengineering.stackexchange.com/questions/297276/what-is-a-shaded-java-dependency